### PR TITLE
Allow REST server to handle multiple jobs

### DIFF
--- a/PrintHtml.pro
+++ b/PrintHtml.pro
@@ -12,9 +12,11 @@ QT += network webkit
 
 HEADERS = stable.h \
     globals.h \
-    printhtml.h
+    printhtml.h \
+    restserver.h
 SOURCES = main.cpp \
-    printhtml.cpp
+    printhtml.cpp \
+    restserver.cpp
 FORMS =
 RESOURCES =
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The program is pretty simple and the command line usage is like this:
 
 ~~~~
 Usage: PrintHtml [-test] [-p printer] [-l left] [-t top] [-r right] [-b bottom] [-a paper] [-o orientation] [-pagefrom number] [-pageto number] [-json] <url> [url2]
+       [-server port]
 
 -test                     - Don't print, just show what would have printed.
 -p printer                - Printer to print to. Use 'Default' for default printer.
@@ -35,11 +36,16 @@ Usage: PrintHtml [-test] [-p printer] [-l left] [-t top] [-r right] [-b bottom] 
 -pagefrom [page number]   - Optional. Start page number for printing range.
 -pageto [page number]     - Optional. End page number for printing range.
                             (Must be used together with -pagefrom)
+ -server [port]           - Start REST server on the given port.
 url                       - One or more URLs to print (space-separated).
 
 Example (custom paper size 77x77 mm, no margins):
 
   PrintHtml -p "YourPrinterName" -a "77,77" -l 0 -r 0 -t 0 -b 0 "https://example.com"
+
+REST server example (listen on port 9090):
+
+  PrintHtml -server 9090
 ~~~~
 
 ---
@@ -124,10 +130,10 @@ been quite a few discussion about this that I could find on the web, but no solu
 If anyone has ideas about how to fix this it would be great to add some options to control the headers
 and footers to this program.
 
-# Potential improvements
+# REST server mode
 
-Something that would cool to add, but I am not familar enough with Qt and C++ these days to implement, would be
-to turn this application into a small REST server that would sit in the background and accept URL's and related
-options to print them over the wire so it would be easy to use from other apps without having to resort to
-executing it on the command line. If someone more familiar with Qt and REST services knows how to build a basic
-REST server into the app that would be a pretty slick improvement.
+PrintHtml can also run as a lightweight REST service. Start the application with
+`-server [port]` (default `8080`) and it will listen for HTTP requests. Send a
+`GET /print` request with query parameters matching the command line options
+(such as `url`, `printer`, `left`, `top`, etc.) and the requested page will be
+printed.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Example (custom paper size 77x77 mm, no margins):
 REST server example (listen on port 9090):
 
   PrintHtml -server 9090
+
+Custom size via REST:
+
+  http://localhost:9090/print?url=https://example.com&a=77,77
 ~~~~
 
 ---
@@ -136,4 +140,5 @@ PrintHtml can also run as a lightweight REST service. Start the application with
 `-server [port]` (default `8080`) and it will listen for HTTP requests. Send a
 `GET /print` request with query parameters matching the command line options
 (such as `url`, `printer`, `left`, `top`, etc.) and the requested page will be
-printed.
+printed. Custom paper sizes can be provided using `width` and `height` query
+parameters or the shorthand `a=WIDTH,HEIGHT`.

--- a/printhtml.cpp
+++ b/printhtml.cpp
@@ -31,7 +31,7 @@
  */
 PrintHtml::PrintHtml(bool testMode, bool json, QStringList urls, QString selectedPrinter, double leftMargin, double topMargin,
                      double rightMargin, double bottomMargin, QString paper, QString orientation, int pageFrom, int pageTo,
-                     double paperWidth, double paperHeight)
+                     double paperWidth, double paperHeight, bool exitOnCompletion)
 {
     // Get the instance of the main application
     app = QCoreApplication::instance();
@@ -80,6 +80,7 @@ PrintHtml::PrintHtml(bool testMode, bool json, QStringList urls, QString selecte
     this->paperWidth = paperWidth;
     this->paperHeight = paperHeight;
     this->paperSizeName = paper;
+    this->exitOnCompletion = exitOnCompletion;
 
 }
 
@@ -157,7 +158,8 @@ void PrintHtml::htmlLoaded(
 
                 }
                 printf("{\"error\":[" + failed.left(failed.length() - 1).toLatin1() + "],\"success\":[" + succeeded.left(succeeded.length() - 1).toLatin1() + "]}");
-                QCoreApplication::exit(0);
+                if (exitOnCompletion)
+                    QCoreApplication::exit(0);
             }
         } else {
             error << this->url;
@@ -177,7 +179,8 @@ void PrintHtml::htmlLoaded(
 
                 }
                 printf("{\"error\":[" + failed.left(failed.length()-1).toLatin1() + "],\"success\":[" + succeeded.left(succeeded.length() - 1).toLatin1() + "]}");
-                QCoreApplication::exit(0);
+                if (exitOnCompletion)
+                    QCoreApplication::exit(0);
             }
         }
     } else {
@@ -195,14 +198,16 @@ void PrintHtml::htmlLoaded(
                     msgBox.setText(printed.join("\n"));
                     msgBox.exec();
                 }
-                QCoreApplication::exit(0);
+                if (exitOnCompletion)
+                    QCoreApplication::exit(0);
             }
         } else {
             QMessageBox msgBox;
             msgBox.setWindowTitle("Fatal Error");
             msgBox.setText("HTML page failed to load!");
             msgBox.exec();
-            QCoreApplication::exit(-1);
+                if (exitOnCompletion)
+                    QCoreApplication::exit(-1);
         }
     }
 

--- a/printhtml.h
+++ b/printhtml.h
@@ -38,7 +38,7 @@ private:
 public:
     PrintHtml(bool testMode, bool json, QStringList urls, QString selectedPrinter, double leftMargin, double topMargin,
           double rightMargin, double bottomMargin, QString paper, QString orientation, int pageFrom, int pageTo,
-          double paperWidth = 0, double paperHeight = 0);
+          double paperWidth = 0, double paperHeight = 0, bool exitOnCompletion = true);
     void quit();
 
 private:
@@ -68,6 +68,7 @@ private:
     QWebPage        *webPage;   // QWebPage class for printing
     QString         url;
     QStringList     printed;
+    bool            exitOnCompletion; // Whether to exit the app when done
 };
 
 #endif // PRINTHTML_H

--- a/restserver.cpp
+++ b/restserver.cpp
@@ -1,0 +1,82 @@
+#include "restserver.h"
+#include <QUrl>
+#include <QTimer>
+
+RestServer::RestServer(QObject *parent)
+    : QObject(parent)
+{
+    connect(&server, SIGNAL(newConnection()), this, SLOT(newConnection()));
+}
+
+bool RestServer::listen(quint16 port)
+{
+    return server.listen(QHostAddress::Any, port);
+}
+
+void RestServer::newConnection()
+{
+    QTcpSocket *client = server.nextPendingConnection();
+    connect(client, SIGNAL(readyRead()), this, SLOT(readClient()));
+    connect(client, SIGNAL(disconnected()), client, SLOT(deleteLater()));
+}
+
+static QMap<QString, QString> parseQuery(const QString &query)
+{
+    QMap<QString, QString> params;
+    foreach (const QString &pair, query.split('&', QString::SkipEmptyParts)) {
+        int eq = pair.indexOf('=');
+        if (eq > 0) {
+            QString key = QUrl::fromPercentEncoding(pair.left(eq).toUtf8());
+            QString val = QUrl::fromPercentEncoding(pair.mid(eq+1).toUtf8());
+            params.insert(key, val);
+        }
+    }
+    return params;
+}
+
+void RestServer::readClient()
+{
+    QTcpSocket *client = qobject_cast<QTcpSocket*>(sender());
+    if (!client)
+        return;
+    if (!client->canReadLine())
+        return;
+
+    QString requestLine = QString::fromUtf8(client->readLine()).trimmed();
+    if (!requestLine.startsWith("GET")) {
+        client->write("HTTP/1.1 400 Bad Request\r\n\r\n");
+        client->disconnectFromHost();
+        return;
+    }
+
+    QString path = requestLine.section(' ', 1, 1);
+    QString endpoint = path.section('?', 0, 0);
+    QString query = path.section('?', 1);
+    QMap<QString, QString> params = parseQuery(query);
+
+    if (endpoint == "/print" && params.contains("url")) {
+        QStringList urls; urls << params.value("url");
+        QString printer = params.value("printer", "Default");
+        double l = params.value("left", "0.5").toDouble();
+        double t = params.value("top", "0.5").toDouble();
+        double r = params.value("right", "0.5").toDouble();
+        double b = params.value("bottom", "0.5").toDouble();
+        QString paper = params.value("paper", "A4");
+        QString orient = params.value("orientation", "portrait");
+        int pageFrom = params.value("pagefrom", "0").toInt();
+        int pageTo = params.value("pageto", "0").toInt();
+        double width = params.value("width", "0").toDouble();
+        double height = params.value("height", "0").toDouble();
+
+        PrintHtml *job = new PrintHtml(false, true, urls, printer, l, t, r, b, paper, orient, pageFrom, pageTo, width, height, false);
+        connect(job, SIGNAL(finished()), job, SLOT(deleteLater()));
+        QTimer::singleShot(0, job, SLOT(run()));
+
+        QByteArray resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nPrinting started";
+        client->write(resp);
+        client->disconnectFromHost();
+    } else {
+        client->write("HTTP/1.1 404 Not Found\r\n\r\n");
+        client->disconnectFromHost();
+    }
+}

--- a/restserver.cpp
+++ b/restserver.cpp
@@ -67,6 +67,18 @@ void RestServer::readClient()
         int pageTo = params.value("pageto", "0").toInt();
         double width = params.value("width", "0").toDouble();
         double height = params.value("height", "0").toDouble();
+        if (params.contains("a") && params.value("a").contains(',')) {
+            QStringList dims = params.value("a").split(',');
+            if (dims.size() == 2) {
+                bool ok1, ok2;
+                double w = dims[0].toDouble(&ok1);
+                double h = dims[1].toDouble(&ok2);
+                if (ok1 && ok2 && w > 0 && h > 0) {
+                    width = w;
+                    height = h;
+                }
+            }
+        }
 
         PrintHtml *job = new PrintHtml(false, true, urls, printer, l, t, r, b, paper, orient, pageFrom, pageTo, width, height, false);
         connect(job, SIGNAL(finished()), job, SLOT(deleteLater()));

--- a/restserver.h
+++ b/restserver.h
@@ -1,0 +1,24 @@
+#ifndef RESTSERVER_H
+#define RESTSERVER_H
+
+#include <QObject>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include "printhtml.h"
+
+class RestServer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RestServer(QObject *parent = 0);
+    bool listen(quint16 port);
+
+private slots:
+    void newConnection();
+    void readClient();
+
+private:
+    QTcpServer server;
+};
+
+#endif // RESTSERVER_H


### PR DESCRIPTION
## Summary
- keep the application running when jobs are dispatched from the REST server
- pass a `exitOnCompletion` flag so server jobs do not quit the app

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847332158808332b88ff22e458e9499