### PR TITLE
Add short REST params and JSON replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ and footers to this program.
 
 PrintHtml can also run as a lightweight REST service. Start the application with
 `-server [port]` (default `8080`) and it will listen for HTTP requests. Send a
-`GET /print` request with query parameters matching the command line options
-(such as `url`, `printer`, `left`, `top`, etc.) and the requested page will be
-printed. Custom paper sizes can be provided using `width` and `height` query
-parameters or the shorthand `a=WIDTH,HEIGHT`.
+`GET /print` request using query parameters that match the command line options
+(such as `url`, `printer`, `left`, `top`, etc.) or their short forms (`p`, `l`,
+`t`, `r`, `b`, `o`, `a`). The server accepts either style of parameter and
+always returns a JSON response. Custom paper sizes can be provided using
+`width` and `height` query parameters or the shorthand `a=WIDTH,HEIGHT`.


### PR DESCRIPTION
## Summary
- support short option names in REST server
- return JSON from REST responses
- update documentation for REST server options

## Testing
- `make -n` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_684803a24c5883328e0470f70f4e8520